### PR TITLE
Move vframes flag after input and change Popen from wait to communicate

### DIFF
--- a/pythonbits.py
+++ b/pythonbits.py
@@ -652,7 +652,7 @@ class Imgur(object):
 			count=0
 			for stop in stops:
 				imgs.append(TMPDIR+"screen%d.png" % count)
-				subprocess.Popen([r"ffmpeg","-ss",str((self.duration * stop)/100), "-vframes", "1", "-i", self.path , "-y", "-sameq", "-f", "image2", imgs[-1] ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).wait()
+				subprocess.Popen([r"ffmpeg","-ss",str((self.duration * stop)/100), "-i", self.path , "-vframes", "1", "-y", "-qscale", "0", "-f", "image2", imgs[-1] ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()
 				count+=1
 		except OSError:
 			sys.stderr.write("Error: Ffmpeg not installed, refer to http://www.ffmpeg.org/download.html for installation")


### PR DESCRIPTION
New versions of ffmpeg check the location of vframes and will throw an error if it's specified before the input. 
Also changed wait to communicate (not sure if that's actually doing anything but people on bB think it does).
